### PR TITLE
fix: remove blockquote from language switch links in READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/popyson1648/skill-forge-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/popyson1648/skill-forge-mcp/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-> [English](README.md)
+[English](README.md)
 
 [Agent Skill](https://github.com/anthropics/skills) の作成手順書（9 フェーズ）を MCP リソースとして提供するサーバーです。
 AI エージェントが必要なフェーズだけをオンデマンドで取得し、手順に沿って SKILL.md を作成できます。

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/popyson1648/skill-forge-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/popyson1648/skill-forge-mcp/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-> [日本語](README.ja.md)
+[日本語](README.ja.md)
 
 An MCP server that exposes the [Agent Skill](https://github.com/anthropics/skills) creation guide (9 phases) as MCP resources.
 AI agents retrieve only the phases they need on demand and follow the process to build SKILL.md files.


### PR DESCRIPTION
Remove the blockquote (`>`) prefix from the language switch links at the top of README.md and README.ja.md, converting them to plain links.