### PR TITLE
release: merge dev into main (fix README language links)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/popyson1648/skill-forge-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/popyson1648/skill-forge-mcp/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-> [English](README.md)
+[English](README.md)
 
 [Agent Skill](https://github.com/anthropics/skills) の作成手順書（9 フェーズ）を MCP リソースとして提供するサーバーです。
 AI エージェントが必要なフェーズだけをオンデマンドで取得し、手順に沿って SKILL.md を作成できます。

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/popyson1648/skill-forge-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/popyson1648/skill-forge-mcp/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-> [日本語](README.ja.md)
+[日本語](README.ja.md)
 
 An MCP server that exposes the [Agent Skill](https://github.com/anthropics/skills) creation guide (9 phases) as MCP resources.
 AI agents retrieve only the phases they need on demand and follow the process to build SKILL.md files.


### PR DESCRIPTION
## Description

Remove blockquote (`>`) prefix from language switch links at the top of README.md and README.ja.md.

Fixes #6

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Tests (adding or updating tests)
- [ ] Chore (dependency updates, CI changes, etc.)

## Changes Made

- Removed `>` (blockquote) prefix from the Japanese language link in README.md
- Removed `>` (blockquote) prefix from the English language link in README.ja.md

## Checklist

- [x] My code follows the project's coding style
- [x] I have added/updated tests as appropriate
- [x] All tests pass locally (`npm test`)
- [x] The build succeeds (`npm run build`)
- [x] I have updated documentation if needed

## Testing

No functional code changes. Verified Markdown renders correctly without blockquote styling.

## Screenshots (if applicable)

## Additional Notes
